### PR TITLE
grapher.php isn't generating any edges

### DIFF
--- a/grapher.php
+++ b/grapher.php
@@ -162,7 +162,7 @@ function gather_data($namespaces,$depth=0,$incmedia='ns'){
     // now get links and media
     foreach($pages as $pid => $item){
         // get instructions
-        $ins = p_cached_instructions(wikiFN($pid),true,$pid);
+        $ins = p_cached_instructions(wikiFN($pid),false,$pid);
         // find links and media usage
         foreach($ins as $i){
             $mid = null;


### PR DESCRIPTION
Hi, **grapher.php** isn't generating any edges.

solution: change the Value of the Boolean in Line 165 from true to false.
Before:
$ins = p_cached_instructions(wikiFN($pid),**true**,$pid);
After:
$ins = p_cached_instructions(wikiFN($pid),**false**,$pid);

refs:
http://www.splitbrain.org/blog/2010-08/02-graphing_dokuwiki_help_needed

I've just try and the solution works nice !

Cheers
